### PR TITLE
Add quote-reply support to messaging events

### DIFF
--- a/dist/models/messageModel.d.ts
+++ b/dist/models/messageModel.d.ts
@@ -25,6 +25,7 @@ export interface IMessage extends Document {
     isActive: boolean;
     isTTS: boolean;
     currentEmoji: string;
+    replyTo?: IMessage;
     expiresAt: Date;
     createdAt: Date;
     updatedAt: Date;

--- a/dist/models/messageModel.js
+++ b/dist/models/messageModel.js
@@ -74,6 +74,7 @@ const MessageSchema = new mongoose_1.Schema({
     isActive: { type: Boolean, default: true },
     isTTS: { type: Boolean, default: false },
     currentEmoji: { type: String, default: exports.MESSAGE_EMOJIS[0] },
+    replyTo: { type: mongoose_1.Schema.Types.ObjectId, ref: "Messages", default: null },
     expiresAt: { type: Date },
 }, {
     timestamps: true, // Adds createdAt and updatedAt fields

--- a/models/messageModel.ts
+++ b/models/messageModel.ts
@@ -47,6 +47,7 @@ export interface IMessage extends Document {
   isActive: boolean; // false after 12 hours
   isTTS: boolean;
   currentEmoji: string; // populated from hour 6 onwards
+  replyTo?: IMessage;
   expiresAt: Date;
   createdAt: Date;
   updatedAt: Date;
@@ -76,6 +77,7 @@ const MessageSchema: Schema = new Schema(
     isActive: { type: Boolean, default: true },
     isTTS: { type: Boolean, default: false },
     currentEmoji: { type: String, default: MESSAGE_EMOJIS[0] },
+    replyTo: { type: Schema.Types.ObjectId, ref: "Messages", default: null },
     expiresAt: { type: Date },
   },
   {


### PR DESCRIPTION
  send-message and resend-message now accept a replyTo message ID.
  get-messages, receive-message, and messages-sent responses include a
  shaped replyTo preview (sender + type-specific fields) via a shared
  messageService helper, so every event returns a consistent shape.

  Switches findMessagesByChatRoomId, createMessageService,
  findMessageByIdAndUpdate, and findOneMessageNotPlayedByUserAndUpdate
  to .lean()/.toObject() to make the replyTo reshaping safe. Restores
  the uid=197609(HP) gid=197121 groups=197121 virtual field that Mongoose's toJSON (virtuals: true) used to
  add automatically, so the response shape for message/user objects is
  otherwise unchanged from before.